### PR TITLE
Fix base file import bugs in openvoicechat/openvoicechat/*

### DIFF
--- a/openvoicechat/llm/llm_gpt.py
+++ b/openvoicechat/llm/llm_gpt.py
@@ -1,4 +1,7 @@
-from .base import BaseChatbot
+if __name__ == '__main__':
+    from base import BaseChatbot
+else:
+    from .base import BaseChatbot
 import os
 
 class Chatbot_gpt(BaseChatbot):

--- a/openvoicechat/stt/stt_hf.py
+++ b/openvoicechat/stt/stt_hf.py
@@ -1,5 +1,8 @@
 import torch
-from .base import BaseEar
+if __name__ == '__main__':
+    from base import BaseEar
+else:
+    from .base import BaseEar
 import numpy as np
 
 

--- a/openvoicechat/stt/stt_vosk.py
+++ b/openvoicechat/stt/stt_vosk.py
@@ -1,7 +1,10 @@
 import numpy as np
 import json
 
-from .base import BaseEar
+if __name__ == '__main__':
+    from base import BaseEar
+else:
+    from .base import BaseEar
 
 class Ear_vosk(BaseEar):
     def __init__(self, model_path='models/vosk-model-en-us-0.22', device='cpu', silence_seconds=2):

--- a/openvoicechat/tts/tts_hf.py
+++ b/openvoicechat/tts/tts_hf.py
@@ -1,6 +1,9 @@
 import sounddevice as sd
 import torch
-from .base import BaseMouth
+if __name__ == '__main__':
+    from base import BaseMouth
+else:
+    from .base import BaseMouth
 
 
 class Mouth_hf(BaseMouth):

--- a/openvoicechat/tts/tts_parler.py
+++ b/openvoicechat/tts/tts_parler.py
@@ -1,8 +1,11 @@
 import torch
 from transformers import AutoTokenizer
 from transformers.modeling_outputs import BaseModelOutput
-from .base import BaseMouth
 import sounddevice as sd
+if __name__ == '__main__':
+    from base import BaseMouth
+else:
+    from .base import BaseMouth
 
 
 '''


### PR DESCRIPTION
There were bugs importing the base file for llm, tts, and stt in certain files for example tts_hf.py:
```python
if __name__ == '__main__':
    from base import BaseMouth
else:
    from .base import BaseMouth
```